### PR TITLE
bugfix: Validate if quantity has changed

### DIFF
--- a/src/Synolia/Bundle/StockAlertBundle/EventListener/InventoryLevelNotificationEventListener.php
+++ b/src/Synolia/Bundle/StockAlertBundle/EventListener/InventoryLevelNotificationEventListener.php
@@ -63,8 +63,12 @@ class InventoryLevelNotificationEventListener
 
     protected function inventoryHasNewStock(PreUpdateEventArgs $args): bool
     {
-        $oldQuantity = floatval($args->getOldValue('quantity'));
-        $newQuantity = floatval($args->getNewValue('quantity'));
+        if (!$args->hasChangedField('quantity')) {
+            return false;
+        }
+
+        $oldQuantity = (float) $args->getOldValue('quantity');
+        $newQuantity = (float) $args->getNewValue('quantity');
 
         return $oldQuantity <= 0 && $newQuantity > 0;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed issue |

It is necessary validate if quantity has change before to try to get the old and new values.