### PR TITLE
fix: replace removed DBAL4 'json_array' type in install migration

### DIFF
--- a/src/Synolia/Bundle/StockAlertBundle/Migrations/Schema/SynoliaStockAlertBundleInstaller.php
+++ b/src/Synolia/Bundle/StockAlertBundle/Migrations/Schema/SynoliaStockAlertBundleInstaller.php
@@ -48,7 +48,7 @@ class SynoliaStockAlertBundleInstaller implements Installation
                 ],
             ]
         );
-        $table->addColumn('serialized_data', 'json_array', ['jsonb' => true, 'notnull' => false, 'length' => 0, 'comment' => '(DC2Type:array)']);
+        $table->addColumn('serialized_data', Types::JSON, ['notnull' => false]);
         $table->addColumn('expiration_date', 'datetime', ['notnull' => false, 'length' => 0, 'comment' => '(DC2Type:datetime)']);
         $table->addColumn('created_at', 'datetime', ['length' => 0, 'comment' => '(DC2Type:datetime)']);
         $table->addColumn('updated_at', 'datetime', ['length' => 0, 'comment' => '(DC2Type:datetime)']);


### PR DESCRIPTION
## Why

A fresh `oro:install` on OroCommerce 7.0 aborts with:

```
ERROR: Unknown column type "json_array" requested. Any Doctrine type that you use has to be registered with \Doctrine\DBAL\Types\Type::addType().
> Synolia\Bundle\StockAlertBundle\Migrations\Schema\SynoliaStockAlertBundleInstaller
```

DBAL 4 (shipped with OroCommerce 7.0 / Symfony 7) **removed the `json_array` column type** (deprecated since DBAL 2.6, gone in DBAL 3). The installer still declared `serialized_data` as `json_array`, so the install aborts before `synolia_stock_alert` is created.

This was invisible to the `oro:platform:update` path (an existing migrated DB short-circuits `getMigrationVersion()` and never runs the table creation), so it only surfaces on a **from-scratch install** (CI / clean environments).

## What

`serialized_data` now uses the native `Types::JSON`, which is the Oro 7.0 convention for the serialized-data column of extend entities. The stale legacy `(DC2Type:array)` comment and `length => 0` are dropped accordingly.

```diff
-$table->addColumn('serialized_data', 'json_array', ['jsonb' => true, 'notnull' => false, 'length' => 0, 'comment' => '(DC2Type:array)']);
+$table->addColumn('serialized_data', Types::JSON, ['notnull' => false]);
```

Follow-up to the 7.0 migration (#15): this DBAL 4 break in the migration installer was missed there.