### PR TITLE
fix: require authenticated customer on stock alert frontend routes

### DIFF
--- a/src/Synolia/Bundle/StockAlertBundle/Controller/Frontend/StockAlertController.php
+++ b/src/Synolia/Bundle/StockAlertBundle/Controller/Frontend/StockAlertController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Synolia\Bundle\StockAlertBundle\Controller\Frontend;
 
 use Doctrine\Persistence\ObjectManager;
+use Oro\Bundle\CustomerBundle\Entity\CustomerUser;
 use Oro\Bundle\LayoutBundle\Attribute\Layout;
 use Oro\Bundle\ProductBundle\Entity\Product;
 use Oro\Bundle\SecurityBundle\Attribute\CsrfProtection;
@@ -43,6 +44,8 @@ class StockAlertController extends AbstractController
     #[Route(path: '/form/{productId}', name: 'synolia_frontend_stock_alert_form', methods: ['POST']) ]
     public function form(Request $request, int $productId): Response
     {
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_REMEMBERED');
+
         $product = $this->manager->getRepository(Product::class)->find($productId);
 
         $formEntity = new StockAlert();
@@ -83,20 +86,23 @@ class StockAlertController extends AbstractController
     #[Layout(vars: ['entity_class','organization_id','customer_user_id'])]
     public function indexAction(): array
     {
-        $entityClass = StockAlert::class;
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_REMEMBERED');
+
+        /** @var CustomerUser $user */
+        $user = $this->getUser();
 
         return [
-            'entity_class' => $entityClass,
-            /* @phpstan-ignore-next-line */
-            'organization_id' => $this->getUser()->getOrganization()->getId(),
-            /* @phpstan-ignore-next-line */
-            'customer_user_id' => $this->getUser()->getId(),
+            'entity_class' => StockAlert::class,
+            'organization_id' => $user->getOrganization()->getId(),
+            'customer_user_id' => $user->getId(),
         ];
     }
 
     #[Route(path: '/create/{id}', name: 'synolia_stock_alert_create', requirements: ['id' => '\d+']) ]
     public function createAction(#[MapEntity(id: 'id')] Product $product): JsonResponse
     {
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_REMEMBERED');
+
         try {
             $stockAlert = $this->handler->create($product);
 
@@ -119,6 +125,8 @@ class StockAlertController extends AbstractController
     #[CsrfProtection()]
     public function deleteAction(#[MapEntity(id: 'id')] Product $product): JsonResponse
     {
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_REMEMBERED');
+
         try {
             $this->handler->deleteByProduct($product);
 


### PR DESCRIPTION
## Why

The frontend `/stock-alert/*` routes are only hidden through the customer account menu, but they are not protected at the route level. An anonymous visitor — or a crawler — hitting `/stock-alert/` reaches `indexAction()` directly.

There, `getUser()` returns a `CustomerVisitor` (from the `AnonymousCustomerUserToken`), which has **no** `getOrganization()` nor `getId()`. The result is a 500:

```
NoSuchPropertyException: There is no "getOrganization" method in
"Oro\Bundle\CustomerBundle\Entity\CustomerVisitor" entity
```

The `@phpstan-ignore-next-line` hints already flagged that these accesses were not type-safe.

## What

Guard the four frontend actions (`form`, `indexAction`, `createAction`, `deleteAction`) with `denyAccessUnlessGranted('IS_AUTHENTICATED_REMEMBERED')` — the same check Oro uses on its own "my account" pages (`CustomerUserProfileController::profileAction`). Anonymous visitors are now redirected to login, while remember-me sessions keep working (`REMEMBERED`, not `FULLY`).

Since the user is then guaranteed to be a `CustomerUser`, the `@phpstan-ignore-next-line` hints in `indexAction` are removed.

## Notes

7.0 line (master). Same fix is opened against the `6.0` branch in synolia/OroCommerceStockAlertPlugin#18.